### PR TITLE
Add .gitignore to ignore unnecessary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Python cache and compiled files
+__pycache__/
+*.pyc
+
+# Environment and virtual environment
+.env
+venv/
+
+# Database file
+db.sqlite3
+
+# OS-generated files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
### Changes:
- Added a `.gitignore` file to prevent unnecessary files from being tracked.
- Ignored Python cache files (`__pycache__`, `*.pyc`), virtual environment (`venv/`), and database (`db.sqlite3`).
- This improves repository cleanliness and prevents committing unnecessary files.

### Why?
- Helps keep the repo clean.
- Avoids tracking large or system-generated files.


"Let me know if you’d like any modifications to the .gitignore file!"