### PR TITLE
Added profile image in post section (#11)

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -26,6 +26,8 @@ class Post(models.Model):
 
     def __str__(self):
         return self.user
+    
+    # updated for profile image in post section  
     @property
     def profile_image(self):
         from django.contrib.auth import get_user_model


### PR DESCRIPTION
This PR adds the profile image of the user who posted a picture. The issue required displaying the user’s profile image alongside their post.

Changes Made
Added a new property in the Post model to store the user’s profile image.
Updated the HTML template to display the profile image next to the post.
Ensured that a default image is shown if the user does not have a profile picture.

screenshots of the changes
![Screenshot 2025-03-16 194907](https://github.com/user-attachments/assets/af9bc67b-41ce-4451-9c77-fa3b9e674aef)
![Screenshot 2025-03-16 194920](https://github.com/user-attachments/assets/03f0a6b1-9bf5-4aa6-ac68-59af36f3b094)


Closes #11
