### PR TITLE
Fix: add_comment now correctly accepts post_id (#23)

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -12,5 +12,6 @@ urlpatterns = [
     path('signup', views.signup, name='signup'),
     path('signin', views.signin, name='signin'),
     path('logout', views.logout, name='logout'),
-    path('comment/', views.add_comment, name='add-comment'),
+   path('comment/<str:post_id>/', views.add_comment, name='add-comment'),
+
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -17,13 +17,13 @@ from django.http import HttpResponseBadRequest
 from .models import Post, Comment
 
 @login_required(login_url='signin')
-def add_comment(request):
+def add_comment(request,post_id):
     if request.method == 'POST':
         text = request.POST.get('comment_text')
-        post_id = request.GET.get('post_id')
+        # post_id = request.GET.get('post_id')
 
-        if not post_id or not text:
-            return HttpResponseBadRequest("Missing post_id or comment_text.")
+        # if not post_id or not text:
+        #     return HttpResponseBadRequest("Missing post_id or comment_text.")
 
         post = get_object_or_404(Post, id=post_id)
 


### PR DESCRIPTION

Fixed the add_comment view to correctly accept post_id as a URL parameter instead of fetching it from GET parameters.
Updated core/urls.py to ensure the correct URL pattern for adding comments.

Changes Made
Modified core/views.py to accept post_id as a function argument.
Updated core/urls.py to use path('comment/<str:post_id>/') correctly.

screen shot after change
![Screenshot 2025-03-24 202359](https://github.com/user-attachments/assets/7b4fa070-dca6-4dcc-b36c-f42b881e78de)


Closes #23 

